### PR TITLE
Correct nginx documentation

### DIFF
--- a/content/en/docs/deployment/internet.md
+++ b/content/en/docs/deployment/internet.md
@@ -82,12 +82,8 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
     
-    location ~* /static/ {
-        add_header Cache-Control "public, max-age=2678400, must-revalidate";
-    }
-    
     location /ws {
-        proxy_pass http://127.0.0.1:8125;
+        proxy_pass http://127.0.0.1:<port>;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
Having a specific port make is seem like it's using a 2nd port but it's actually not.

Not sure about the reason for the cache control header ? It seems to prevent access to the CSS for me